### PR TITLE
Green Software Maturity Matrix image path correction

### DIFF
--- a/docs/gsmm/index.md
+++ b/docs/gsmm/index.md
@@ -9,7 +9,7 @@ sidebar_label: Green Maturity Matrix
 
 What does this mean in a green software context for an organization? Let’s be realistic. Almost all enterprises are at level 1 right now. Going green is the most difficult project our industry faces.
 
-[![Green Software Maturity Matrix!](/img/maturity-matrix.svg "Green Software Maturity Matrix")](/img/maturity-matrix.svg)
+[![Green Software Maturity Matrix!](/static/img/maturity-matrix.svg "Green Software Maturity Matrix")](/static/img/maturity-matrix.svg)
 
 
 ## Level 1 - Aspiring


### PR DESCRIPTION
Image not showing, probably because of wrong path 
<img width="1541" alt="image" src="https://github.com/Green-Software-Foundation/green-software-maturity-matrix/assets/259956/4372b9b6-b428-4855-be62-fa9b66018ab5">
